### PR TITLE
find the absolute path for the audio and not the relative path accord…

### DIFF
--- a/src/retico_wozmic/WOZ_microphone.py
+++ b/src/retico_wozmic/WOZ_microphone.py
@@ -11,6 +11,7 @@ import keyboard
 import pyaudio
 import wave
 import scipy.io.wavfile as wav
+import os
 
 import retico_core
 from retico_core.audio import AudioIU, MicrophoneModule
@@ -36,6 +37,10 @@ class WOZMicrophoneModule(MicrophoneModule):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        if not os.path.isabs(file):
+            base_dir = os.path.dirname(os.path.abspath(__file__))
+            file = os.path.join(base_dir, file)
+            
         self.file = file
         self.frame_length = frame_length
         self._run_thread_active = False


### PR DESCRIPTION
Fixes relative path on linux.

When using this library on linux python looks for audio file in current work directory

not in site-packages/retico-wozmic/audios...

thus we need to define relative file paths
